### PR TITLE
Make sure Spaces uploads are private

### DIFF
--- a/src/services/spaces-uploader.ts
+++ b/src/services/spaces-uploader.ts
@@ -116,7 +116,7 @@ export const uploadToSpaces = async (
       Bucket: config.DO_SPACES_BUCKET,
       Key: uniqueFileName,
       Body: fileContent,
-      ACL: "public-read" as ObjectCannedACL,
+      ACL: "private" as ObjectCannedACL,
       ContentType: "text/html",
     };
 


### PR DESCRIPTION
This pull request includes a small but significant change to the `uploadToSpaces` function in `src/services/spaces-uploader.ts`. The change updates the `ACL` property for uploaded files from `"public-read"` to `"private"`, improving the security of uploaded files by restricting public access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated file upload settings so that newly uploaded files are now private instead of publicly accessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->